### PR TITLE
Add text search to points

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
 # ushin-db
 The database for storing USHIN data / querying across the p2p network
+
+## Sorting
+
+When you search for either messages or points, the results will be sorted by their createdAt timestamp with newer items showing up first.
+
+This helps show you more recently authored content first and improves the database efficiency by downloading more recent data using the index.
+
+## Full text search and indexing
+
+You can search points by their contents with `db.searchPointsByContent()`.
+
+This works by taking all the words within the content, deduplicating them, and putting them in a `textSearch` array.
+
+When you search, we split up your words and find all points that contain that set of words.
+
+Generally when searching you'll want to use words that are likely to only appear in the points you wish to find.

--- a/test.js
+++ b/test.js
@@ -102,3 +102,27 @@ test("Able to search for messages in a time range", async (t) => {
     if (db) db.close();
   }
 });
+test("Able to search for documents by their text contents", async (t) => {
+  try {
+    var db = await getNew();
+
+    await db.addPoint({ content: "Hello world", _id: "one" });
+    await db.addPoint({ content: "Goodbye world", _id: "two" });
+
+    const results1 = await db.searchPointsByContent("world");
+    const results1Ids = results1.map(({ _id }) => _id);
+
+    // Note that the sort order has newer points first
+    t.deepEqual(results1Ids, ["two", "one"], "Got expected point IDs");
+
+    const results2 = await db.searchPointsByContent("hello");
+    const results2Ids = results2.map(({ _id }) => _id);
+
+    t.deepEqual(results2Ids, ["one"], "Got just the matching document");
+  } catch (e) {
+    t.error(e);
+  } finally {
+    if (db) db.close();
+    t.end();
+  }
+});


### PR DESCRIPTION
Also added default sorting to searching for messages.

A description of how it works is in the README.

@josephmturner Do the unit tests make sense to you?

Would a test showing how you can search for a message with points with a given text content be good as a next step?